### PR TITLE
Remove worker allocation. Procfile doesn't start any workers.

### DIFF
--- a/app.json
+++ b/app.json
@@ -33,9 +33,6 @@
     }
   },
   "formation": {
-    "worker": {
-      "quantity": 1
-    },
     "web": {
       "quantity": 1
     }


### PR DESCRIPTION
Worker allocation was set in `app.json` by habit (accident) but no worker was started in `Procfile`. This was causing review apps to fail in creation/launch. Removed the allocation because we don't need workers (at least right now).