### PR TITLE
Upon failure to get gps, a CheckIn form should still be submitted

### DIFF
--- a/app/assets/javascripts/geolocate.js
+++ b/app/assets/javascripts/geolocate.js
@@ -17,6 +17,7 @@ $("document").ready(function() {
 
     function failure() {
       $("#left").append("<p> Failure!</p>")
+      $("#new_check_in").submit();
     };
   });
 });


### PR DESCRIPTION
When students either couldn't allow location to be collected or chose to block location collection, the javascript function didn't used to submit the form. Now it does.