### PR TITLE
Intermediate: Add & calculate score to Enrollments

### DIFF
--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -10,6 +10,7 @@
 #  roles      :string
 #  user_id    :integer
 #  context_id :integer
+#  score      :float
 #
 
 class Enrollment < ApplicationRecord

--- a/db/migrate/20190204180703_add_score_to_enrollment.rb
+++ b/db/migrate/20190204180703_add_score_to_enrollment.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddScoreToEnrollment < ActiveRecord::Migration[5.2]
+  def change
+    add_column :enrollments, :score, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_190_111_184_635) do
+ActiveRecord::Schema.define(version: 20_190_204_180_703) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'plpgsql'
 
@@ -69,6 +69,7 @@ ActiveRecord::Schema.define(version: 20_190_111_184_635) do
     t.string 'roles'
     t.integer 'user_id'
     t.integer 'context_id'
+    t.float 'score'
   end
 
   create_table 'launches', force: :cascade do |t|

--- a/lib/tasks/calculate_score_for_enrollment.rake
+++ b/lib/tasks/calculate_score_for_enrollment.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+desc "One-time task to calculate and record an enrollment's score"
+task record_scores_for_enrollments: :environment do
+  Enrollment.find_each do |enrollment|
+    enrollment.update(score: enrollment.grade_attendance)
+  end
+end

--- a/spec/models/enrollment_spec.rb
+++ b/spec/models/enrollment_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: enrollments
@@ -9,4 +10,5 @@
 #  roles      :string
 #  user_id    :integer
 #  context_id :integer
+#  score      :float
 #


### PR DESCRIPTION
We want to implement a Submission model that joins an Enrollment and a Resource. It will have a column, `score`, that contains the current grade for attendance.

Currently, the grade is calculated and not stored in the DB anywhere. This is an intermediate step to add a column to an existing table and run a one-off rake task to calculate all scores and store them in an Enrollment (in the new `score` column).