### PR TITLE
Lp implement submission model

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -152,7 +152,7 @@ Style/FrozenStringLiteralComment:
     to help transition from Ruby 2.3.0 to Ruby 3.0.
   Enabled: false
 
-Style/FlipFlop:
+Lint/FlipFlop:
   Description: 'Checks for flip flops'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-flip-flops'
   Enabled: false

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,6 +17,10 @@ class ApplicationController < ActionController::Base
     @current_enrollment ||= Enrollment.find_by(id: session[:enrollment_id])
   end
 
+  def current_submission
+    @current_submission ||= Submission.find_by(id: session[:submission_id])
+  end
+
   def current_user
     current_enrollment.user
   end

--- a/app/controllers/check_ins_controller.rb
+++ b/app/controllers/check_ins_controller.rb
@@ -3,50 +3,25 @@
 class CheckInsController < ApplicationController
   before_action :set_check_in, only: %i[show edit update destroy approve_check_in disapprove_check_in]
 
-  # GET /check_ins
-  # GET /check_ins.json
   def index
     @check_ins = CheckIn.where(enrollment: current_enrollment)
   end
 
-  # GET /check_ins/1
-  # GET /check_ins/1.json
   def show; end
 
-  # GET /check_ins/new
   def new
     @check_in = CheckIn.new
   end
 
-  # GET /check_ins/1/edit
   def edit; end
 
-  # POST /check_ins
-  # POST /check_ins.json
   def create
-    @check_in = current_enrollment.check_ins.build(check_in_params)
+    @check_in = CheckIn.new(check_in_params)
     @check_in.meeting = current_resource.nearest_meeting
     respond_to do |format|
       if @check_in.save
-
-        provider = IMS::LTI::ToolProvider.new(
-          current_credential.consumer_key,
-          current_credential.consumer_secret,
-          current_launch.payload
-        )
-        p '==================================================================='
-        p 'provider.inspect:'
-        p provider.inspect
-        p '==================================================================='
-        p 'current_launch.payload:'
-        p current_launch.payload
-        p '==================================================================='
-        p "outcome_service: #{provider.outcome_service?}"
-
-        p response = provider.post_replace_result!(current_enrollment.grade_attendance)
-        p result = response.description
-
-        format.html { redirect_to resource_url(@check_in.resource), notice: result }
+        format.html { redirect_to resource_url(@check_in.resource) }
+        # format.html { redirect_to resource_url(@check_in.resource), notice: result }
         format.json { render :show, status: :created, location: @check_in }
       else
         format.html { render :new }
@@ -67,8 +42,6 @@ class CheckInsController < ApplicationController
     end
   end
 
-  # DELETE /check_ins/1
-  # DELETE /check_ins/1.json
   def destroy
     @check_in.destroy
     respond_to do |format|
@@ -91,13 +64,11 @@ class CheckInsController < ApplicationController
 
   private
 
-  # Use callbacks to share common setup or constraints between actions.
   def set_check_in
     @check_in = CheckIn.find(params[:id])
   end
 
-  # Never trust parameters from the scary internet, only allow the white list through.
   def check_in_params
-    params.require(:check_in).permit(:enrollment_id, :meeting_id, :latitude, :longitude, :approved)
+    params.require(:check_in).permit(:submission_id, :meeting_id, :latitude, :longitude, :approved)
   end
 end

--- a/app/controllers/launches_controller.rb
+++ b/app/controllers/launches_controller.rb
@@ -38,6 +38,11 @@ class LaunchesController < ApplicationController
       find_or_create_user
       find_or_create_enrollment
       set_current_enrollment
+      @submission = Submission.find_or_create_by(
+        resource: @resource,
+        enrollment: @enrollment
+      )
+      set_current_submission
       @launch = Launch.new(payload: params, credential: @credential, enrollment: @enrollment)
       if @launch.save
         set_current_launch
@@ -172,6 +177,10 @@ class LaunchesController < ApplicationController
 
   def set_current_enrollment
     session[:enrollment_id] = @enrollment.id
+  end
+
+  def set_current_submission
+    session[:submission_id] = @submission.id
   end
 
   def set_current_launch

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -12,7 +12,7 @@ class ResourcesController < ApplicationController
   # GET /resources/1
   # GET /resources/1.json
   def show
-    @check_in = CheckIn.new(enrollment: current_enrollment)
+    @check_in = CheckIn.new(submission: current_submission)
     if current_enrollment.teacher?
       @meetings = @resource.meetings
       @most_recent_meeting = @resource.meetings.gradeable.order(:start_time).last
@@ -21,7 +21,7 @@ class ResourcesController < ApplicationController
       render 'teacher_show'
     else
       @target_meeting = current_resource.nearest_meeting
-      @check_ins = @resource.check_ins.where(enrollment: current_enrollment)
+      @check_ins = @resource.check_ins.where(submission: current_submission)
 
       render 'learner_show'
     end

--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -10,7 +10,6 @@
 #  roles      :string
 #  user_id    :integer
 #  context_id :integer
-#  score      :float
 #
 
 class Enrollment < ApplicationRecord
@@ -18,9 +17,7 @@ class Enrollment < ApplicationRecord
   belongs_to :user
 
   has_many :launches
-  has_many :check_ins, dependent: :destroy
-  has_many :approved_check_ins, -> { approved }, class_name: 'CheckIn'
-  has_many :approved_meetings, -> { distinct }, through: :approved_check_ins, source: :meeting
+  has_many :submissions
 
   def latest_launch
     launches.order(:created_at).last
@@ -30,27 +27,7 @@ class Enrollment < ApplicationRecord
     Resource.find_by(lti_resource_link_id: latest_launch.payload['resource_link_id'])
   end
 
-  def count_of_gradeable_meetings
-    resource.meetings.gradeable.count
-  end
-
-  def grade_attendance
-    if count_of_gradeable_meetings != 0
-      approved_meetings.count.to_f / count_of_gradeable_meetings.to_f
-    else
-      1.to_f
-    end
-  end
-
   def teacher?
     roles.downcase.include?('teachingassistant') || roles.downcase.include?('instructor')
   end
 end
-
-# Enrollment.all.each do |e|
-#   launch = e.launches.last
-#   user = e.user
-#   user.first_name = launch.payload["lis_person_name_given"]
-#   user.last_name = launch.payload["lis_person_name_family"]
-#   user.save
-# end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -26,7 +26,8 @@ class Resource < ApplicationRecord
   # after_update :create_meetings
 
   belongs_to :context
-  has_many :enrollments, dependent: :destroy
+  has_many :submissions, dependent: :destroy
+  has_many :enrollments, through: :submissions
   has_many :meetings, dependent: :destroy
   has_many :check_ins, through: :meetings
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: submissions
+#
+#  id            :bigint(8)        not null, primary key
+#  enrollment_id :bigint(8)
+#  resource_id   :bigint(8)
+#  score         :float            default(0.0)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (enrollment_id => enrollments.id)
+#  fk_rails_...  (resource_id => resources.id)
+#
+
+class Submission < ApplicationRecord
+  after_update :pass_back_grade
+
+  belongs_to :resource
+  belongs_to :enrollment
+  has_many   :check_ins
+  has_many   :meetings, through: :resource
+
+  has_many :gradeable_meetings, -> { gradeable }, through: :resource, source: :meetings
+  has_many :approved_check_ins, -> { approved }, class_name: 'CheckIn'
+  has_many :approved_meetings, -> { distinct }, through: :approved_check_ins, source: :meeting
+
+  has_one    :user, through: :enrollment
+  has_one    :context, through: :resource
+
+  def pass_back_grade
+    provider = IMS::LTI::ToolProvider.new(
+      context.credential.consumer_key,
+      context.credential.consumer_secret,
+      enrollment.launches.last.payload
+    )
+
+    provider.post_replace_result!(score) if provider.outcome_service?
+  end
+
+  def compute_score
+    if gradeable_meetings.any?
+      approved_meetings.count.to_f / gradeable_meetings.count
+    else
+      1.0
+    end
+  end
+
+  def update_score
+    update(score: compute_score) if score != compute_score
+  end
+end

--- a/app/views/check_ins/_form.html.erb
+++ b/app/views/check_ins/_form.html.erb
@@ -17,6 +17,7 @@
 
     <%= f.hidden_field :latitude, value: nil %>
     <%= f.hidden_field :longitude, value: nil %>
+    <%= f.hidden_field :submission_id, value: check_in.submission_id%>
 
     <% if enrollment_id_was_invalid %>
       <% check_in.errors.full_messages_for(:enrollment_id).each do |message| %>

--- a/app/views/check_ins/_table_row_teacher.html.erb
+++ b/app/views/check_ins/_table_row_teacher.html.erb
@@ -39,7 +39,7 @@
               <strong>Checkin ID: </strong><%= check_in.id %>
             </li>
             <li>
-              <strong>Enrollment ID: </strong><%= check_in.enrollment_id %>
+              <strong>Enrollment ID: </strong><%= check_in.enrollment.id %>
             </li>
             <li>
               <strong>User ID: </strong><%= check_in.user.id %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -57,7 +57,7 @@ Rails.application.configure do
   config.assets.quiet = true
 
   # Bullet configuration
-  Bullet.enable = true
+  Bullet.enable = false
   Bullet.bullet_logger = true
   Bullet.console = true
   Bullet.rails_logger = true

--- a/db/migrate/20190204191638_create_submissions.rb
+++ b/db/migrate/20190204191638_create_submissions.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class CreateSubmissions < ActiveRecord::Migration[5.2]
+  def up
+    create_table :submissions do |t|
+      t.references :enrollment, foreign_key: true
+      t.references :resource, foreign_key: true
+      t.float      :score
+    end
+
+    add_reference :check_ins, :submission, foreign_key: true
+
+    Enrollment.find_each do |enrollment|
+      resource = Resource.find_by(
+        lti_resource_link_id: enrollment.launches.last.payload['resource_link_id']
+      )
+
+      sub = Submission.create(
+        enrollment_id: enrollment.id,
+        resource_id: resource.id,
+        score: enrollment.score
+      )
+
+      enrollment.check_ins.each do |check_in|
+        check_in.update(submission_id: sub.id)
+      end
+    end
+    remove_column :check_ins, :enrollment_id
+    remove_column :enrollments, :score
+  end
+
+  def down
+    add_column :enrollments, :score, :float
+    add_column :check_ins, :enrollment_id, :integer
+
+    Enrollment.find_each do |enrollment|
+      resource = Resource.find_by(
+        lti_resource_link_id: enrollment.launches.last.payload['resource_link_id']
+      )
+      sub = Submission.find_by(
+        enrollment_id: enrollment.id,
+        resource_id: resource.id
+      )
+      enrollment.update(score: sub.score)
+
+      CheckIn.where(submission_id: sub.id).each do |check_in|
+        check_in.update(enrollment_id: enrollment.id)
+      end
+    end
+
+    remove_reference :check_ins, :submission
+    drop_table :submissions
+  end
+end

--- a/db/migrate/20190206181651_add_default_value_to_score_on_submission.rb
+++ b/db/migrate/20190206181651_add_default_value_to_score_on_submission.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDefaultValueToScoreOnSubmission < ActiveRecord::Migration[5.2]
+  def change
+    change_column_default :submissions, :score, from: nil, to: 0.0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_190_204_180_703) do
+ActiveRecord::Schema.define(version: 20_190_206_181_651) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'plpgsql'
 
@@ -38,12 +38,13 @@ ActiveRecord::Schema.define(version: 20_190_204_180_703) do
     t.datetime 'updated_at', null: false
     t.boolean 'present', default: true
     t.boolean 'late'
-    t.integer 'enrollment_id'
     t.boolean 'approved', default: false
     t.float 'latitude'
     t.float 'longitude'
     t.bigint 'meeting_id'
+    t.bigint 'submission_id'
     t.index ['meeting_id'], name: 'index_check_ins_on_meeting_id'
+    t.index ['submission_id'], name: 'index_check_ins_on_submission_id'
   end
 
   create_table 'contexts', force: :cascade do |t|
@@ -69,7 +70,6 @@ ActiveRecord::Schema.define(version: 20_190_204_180_703) do
     t.string 'roles'
     t.integer 'user_id'
     t.integer 'context_id'
-    t.float 'score'
   end
 
   create_table 'launches', force: :cascade do |t|
@@ -106,6 +106,14 @@ ActiveRecord::Schema.define(version: 20_190_204_180_703) do
     t.boolean 'saturday', default: false
   end
 
+  create_table 'submissions', force: :cascade do |t|
+    t.bigint 'enrollment_id'
+    t.bigint 'resource_id'
+    t.float 'score', default: 0.0
+    t.index ['enrollment_id'], name: 'index_submissions_on_enrollment_id'
+    t.index ['resource_id'], name: 'index_submissions_on_resource_id'
+  end
+
   create_table 'users', force: :cascade do |t|
     t.datetime 'created_at', null: false
     t.datetime 'updated_at', null: false
@@ -116,4 +124,7 @@ ActiveRecord::Schema.define(version: 20_190_204_180_703) do
   end
 
   add_foreign_key 'check_ins', 'meetings'
+  add_foreign_key 'check_ins', 'submissions'
+  add_foreign_key 'submissions', 'enrollments'
+  add_foreign_key 'submissions', 'resources'
 end

--- a/spec/models/enrollment_spec.rb
+++ b/spec/models/enrollment_spec.rb
@@ -10,5 +10,4 @@
 #  roles      :string
 #  user_id    :integer
 #  context_id :integer
-#  score      :float
 #


### PR DESCRIPTION
This introduces a new model, Submission, which joins Enrollments and Resources and has many Checkins. This relationship better mirrors a typical LTI setup.

**Migrations**
Aside from setting up the DB schema, the main migration also creates a submission for every enrollment and transfers the score from the enrollment to the submission. It also assigns the correct submission_id to applicable Checkins.

**Callbacks**
The procedure for transmitting scores has been completely reworked. Previously, scores were only transmitted whenever a Checkin was created. This was also being done in the controller. This did not allow for the transmission of a new score upon an instructor approving/disapproving a checkin.

Now, there are callbacks on the CheckIn model and Submission model to pass back the grade to the LMS any time a submission's score is updated.