### PR TITLE
Enable submission pass_back_grade callback

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -16,7 +16,7 @@
 #
 
 class Submission < ApplicationRecord
-  # after_update :pass_back_grade
+  after_update :pass_back_grade
 
   belongs_to :resource
   belongs_to :enrollment


### PR DESCRIPTION
I am enabling the callback in `submission.rb` to run `pass_back_grade` after update. It was disabled to prevent **all** grades being transmitted to the LMS upon doing a previous migration (creating the Submission model). 

Enabling the callback will enable the transmission of updated grades upon checking in and manual approval/disapproval of a checkin