### PR TITLE
Rake task to be run after meetings to pass back submission scores 

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -42,13 +42,13 @@ class Submission < ApplicationRecord
 
   def compute_score
     if gradeable_meetings.any?
-      approved_meetings.count.to_f / gradeable_meetings.count
+      (approved_meetings.count.to_f / gradeable_meetings.count).round(4)
     else
       1.0
     end
   end
 
   def update_score
-    update(score: compute_score) if score != compute_score
+    update(score: compute_score) if score.round(4) != compute_score
   end
 end

--- a/lib/tasks/passback_after_meetings.rake
+++ b/lib/tasks/passback_after_meetings.rake
@@ -1,0 +1,8 @@
+desc "Update score for all submissions of currently active resources"
+task update_active_submissions: :environment do
+  active_resources = Resource.where("ends_on >= ?", Date.today).where("starts_on <= ?", Date.today)
+
+  active_resources.each do |resource|
+    resource.submissions.each(&:update_score)
+  end
+end


### PR DESCRIPTION
Grades need to be passed back to the LMS after a Meeting ends to update the score for students who did not check in.

Since we're planning on fundamentally updating this process after Winter 2019 quarter, I didn't want to get overly specific about which meetings to try to update submission scores for.

Also, I had to alter the Submission#compute_score method. It was returning more digits than are stored in the score column in the DB. This resulted in the comparison in Submission#update_score being inaccurate.