### PR TITLE
Show created_at instead of updated_at for check_ins

### DIFF
--- a/app/views/check_ins/_table_row_learner.html.erb
+++ b/app/views/check_ins/_table_row_learner.html.erb
@@ -5,7 +5,7 @@
 
   <td>
     <%#= check_in.created_at.to_formatted_s(:long) %>
-    <%= check_in.updated_at.strftime("%-I:%M%P %B %-d, %Y") %>
+    <%= check_in.created_at.strftime("%-I:%M%P %B %-d, %Y") %>
   </td>
 
   <td>


### PR DESCRIPTION
A student would see the updated_at time of a checkin instead of the created_at time. This PR fixes that issue.