### PR TITLE
Fix inconsistent button sizing if content is long

### DIFF
--- a/app/views/attendances/_attendance_teacher.html.erb
+++ b/app/views/attendances/_attendance_teacher.html.erb
@@ -26,10 +26,10 @@
           <% end %>
         </div>
       </div>
-      <div class="col-lg-6 three-buttons-container ">
-            <%= attendance_event_button(attendance, :approve) %>
-            <%= attendance_event_button(attendance, :deny) %>
-            <%= attendance_event_button(attendance, :reset) %>
+      <div class="col-lg-6 three-buttons-container p-0">
+        <% Attendance.teacher_events.each do |event| %>
+          <%= attendance_event_button(attendance, event) %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/shared/_event_button.html.erb
+++ b/app/views/shared/_event_button.html.erb
@@ -10,6 +10,7 @@
    "btn",
    "btn-block",
    "btn-#{ contextual_class(event) }",
+   "px-1"
   ]
  %>
  <%


### PR DESCRIPTION
Event buttons were inconsistent sizes because of too much padding around content.

I decreased padding for the event buttons

Also, I refactored building the event buttons on `_attendance_teacher.html.erb` to be DRY

**Old look: **
![Screen Shot 2019-03-20 at 1 52 08 PM](https://user-images.githubusercontent.com/10571382/54711370-c0a6d200-4b17-11e9-85b8-f1fb6627c53a.png)

**New look: **
![Screen Shot 2019-03-20 at 1 52 22 PM](https://user-images.githubusercontent.com/10571382/54711406-d3b9a200-4b17-11e9-8dc2-db0c087383aa.png)