### PR TITLE
Enable grade pass back for Attendance model

### DIFF
--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -21,6 +21,7 @@
 class Attendance < ApplicationRecord
   include AASM
   has_paper_trail
+  after_save :update_submission
 
   belongs_to :meeting
   belongs_to :submission
@@ -30,6 +31,7 @@ class Attendance < ApplicationRecord
   has_one :resource, through: :submission
   has_one :user, through: :enrollment
 
+  scope :accepted, -> { where(status: "accepted") }
   scope :for, ->(submission) { find_by(submission: submission) }
 
   validates_uniqueness_of :submission,
@@ -98,5 +100,9 @@ class Attendance < ApplicationRecord
 
   def allowed_events
     aasm.events.map(&:name)
+  end
+
+  def update_submission
+    submission.update_score
   end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -26,9 +26,16 @@ class Submission < ApplicationRecord
 
   has_many   :meetings, through: :resource
 
-  has_many :gradeable_meetings, -> { gradeable }, through: :resource, source: :meetings
+  has_many :gradeable_meetings,
+           -> { gradeable },
+           through: :resource,
+           source: :meetings
   has_many :approved_check_ins, -> { approved }, class_name: "CheckIn"
-  has_many :approved_meetings, -> { distinct }, through: :approved_check_ins, source: :meeting
+  has_many :accepted_attendances, -> { accepted }, class_name: "Attendance"
+  has_many :approved_meetings,
+           -> { distinct },
+           through: :accepted_attendances,
+           source: :meeting
 
   has_one    :user, through: :enrollment
   has_one    :context, through: :resource


### PR DESCRIPTION
The Attendance model had been implemented for functionality within our app but it was not updating scores to the LMS. This PR makes changes to do so.

Changes: 
- Add callback to Attendances to update an `attendance`'s `submission`'s score.
- Add `accepted` scope to Attendances to find all accepted attendances.
- Add `accepted_attendances` association to Submission
- Modify `approved_meetings` association on Submission to connect through Attendances instead of CheckIns

With these changes, the existing grade pass back logic now works with Attendances.  Since `approved_meetings` now uses Attendances instead of CheckIns, CheckIns grade pass back functionality is broken (computing scores is based off of Attendances now). We had kept the CheckIns model and associated code up until this point because we figured it wasn't interfering. At this point, however, modifications to code are impacting the functionality of CheckIns so eliminating the associated code might be worth considering.