### PR TITLE
Modify rake task to mark attendances absent

### DIFF
--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -22,7 +22,10 @@ class Meeting < ApplicationRecord
   has_one :context, through: :resource
 
   scope :by_date, ->(date) { where(start_time: date.midnight..date.end_of_day) }
-  scope :gradeable, -> { where("start_time <= ?", DateTime.now + 1.hour) }
+  scope :gradeable, -> {
+    where(Meeting.arel_table[:start_time].lteq(Time.current + 1.hour))
+  }
+  scope :finished, -> { where("end_time <= ?", Time.current) }
 
   def has_approved_check_in?(enrollment)
     check_ins = enrollment.check_ins.approved


### PR DESCRIPTION
After a meeting finishes, attendances have to be updated for those who did not check in for the meeting and the new scores need to be transmitted.

Previously, the `update_active_submissions` rake task focused around updating the scores for all submissions within any active resource. The rake task has been renamed to `mark_absent_attendances` and it is oriented to update the Attendances of any meeting that has finished and is currently marked as pending.

Any modification to an attendance will trigger the `update_submission` callback which, in turn, will trigger the grade pass back to the LMS.