### PR TITLE
Change after_update to after_commit on: :update

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -17,7 +17,7 @@
 
 class Submission < ApplicationRecord
   after_create :create_attendances
-  after_update :pass_back_grade
+  after_update_commit :pass_back_grade
 
   belongs_to :resource
   belongs_to :enrollment


### PR DESCRIPTION
If a submission was updated, the method `pass_back_grade` would be called. The `after_update` callback rolls back a change if the method of the callback errs. In this case, we want to ensure that the record is updated in our DB regardless of whether the grade pass back failed or not.

From [Rails Guides](https://guides.rubyonrails.org/active_record_callbacks.html):

>There are two additional callbacks that are triggered by the completion of a database transaction: `after_commit` and `after_rollback`. These callbacks are very similar to the `after_save` callback except that they don't execute until after database changes have either been committed or rolled back. They are most useful when your active record models need to interact with external systems which are not part of the database transaction.