### PR TITLE
Add in_appeal badge

### DIFF
--- a/app/views/resources/show.html+teacher.erb
+++ b/app/views/resources/show.html+teacher.erb
@@ -17,9 +17,9 @@
                         data: { toggle: "list" },
                         aria: { controls: meeting.id } do %>
               <%= meeting %>
-              <span class="badge badge-success badge-pill">
-                <%= meeting.check_ins.count %>
-              </span>
+              <div class="badge badge-warning">
+                <%= meeting.attendances.in_appeal.count %>
+              </div>
             <% end %>
           <% end %>
         </div>


### PR DESCRIPTION
The number of appealed attendances in a meeting is important for an instructor to easily see. This PR adds a badge counter of attendances in appeal.

<img width="686" alt="Screen Shot 2019-04-18 at 10 05 41 AM" src="https://user-images.githubusercontent.com/10571382/56370845-96e9d500-61c1-11e9-87dd-36a1c5adc3c3.png">
