### PR TITLE
Update appeal counter upon AJAXEed change

### DIFF
--- a/app/views/attendances/transition.js+teacher.erb
+++ b/app/views/attendances/transition.js+teacher.erb
@@ -1,1 +1,6 @@
-$("#<%= j dom_id(@attendance) %>").replaceWith("<%= j render "attendance_teacher", attendance: @attendance %>")
+$("#<%= j dom_id(@attendance) %>").replaceWith("<%=
+  j render "attendance_teacher", attendance: @attendance
+%>");
+$("#<%= j dom_id(@attendance.meeting) %>").html("<%=
+  @attendance.meeting.attendances.in_appeal.count
+%>");

--- a/app/views/resources/show.html+teacher.erb
+++ b/app/views/resources/show.html+teacher.erb
@@ -17,7 +17,7 @@
                         data: { toggle: "list" },
                         aria: { controls: meeting.id } do %>
               <%= meeting %>
-              <div class="badge badge-warning">
+              <div class="badge badge-warning" id="<%= dom_id(meeting) %>">
                 <%= meeting.attendances.in_appeal.count %>
               </div>
             <% end %>


### PR DESCRIPTION
After implementing AJAX to handle Attendance event transitions, the appeals counter badge on the meeting ceased updating. This PR fixes that.

![ajax-appeal-counter](https://user-images.githubusercontent.com/10571382/57038197-01b5fa00-6c1f-11e9-9bb7-c46be4257e4c.gif)
