### PR TITLE
Replace task to reject absent attendances

### DIFF
--- a/lib/tasks/passback_after_meetings.rake
+++ b/lib/tasks/passback_after_meetings.rake
@@ -1,13 +1,7 @@
 desc "Mark all pending attendances for finished meetings as absent"
-task mark_absent_attendances: :environment do
-  res = Arel::Table.new(:resources)
-  query = res[:starts_on].lteq(Date.current).
-    and(res[:ends_on].gteq(Date.current))
-  active_resources = Resource.where(query)
+task mark_past_due_pending_attendances_not_approved: :environment do
+  past_due_pending_attendances = Attendance.pending.joins(:meeting).
+    merge(Meeting.finished)
 
-  finished_meetings = Meeting.where(resource: active_resources).finished
-
-  pending_attendances = Attendance.where(meeting: finished_meetings).pending
-
-  pending_attendances.each(&:mark_absent!)
+  past_due_pending_attendances.each(&:mark_absent!)
 end


### PR DESCRIPTION
The previous rake task was unreliably marking past-due attendances as absent. It produced false negatives. Many pending attendances that should have been marked `not_approved` after its meeting had completed were left untouched. Leaving attendances as `not_approved` does not affect accuracy of a calculated score, however, transmission of a score occurs only when an attendance object has been updated. We need scores to be transmitted reliably without the action of a student so LMSes have up to date scoring data. I've refactored and renamed the task to achieve this.

The query now uses a joined and merged query to find all pending attendances of meetings that have finished. It then transitions the state of each attendance to `not_accepted`.