### PR TITLE
Make navbar useable

### DIFF
--- a/app/views/resources/index.html.erb
+++ b/app/views/resources/index.html.erb
@@ -2,10 +2,6 @@
   <div class="col-md-12">
     <h1 class="display-4">
       Resources
-
-      <%= link_to new_resource_path, class: "btn btn-lg btn-outline-secondary" do %>
-        <i class="fas fa-plus fa-fw"></i>
-      <% end %>
     </h1>
   </div>
 </div>
@@ -59,10 +55,6 @@
     <div class="card">
       <h1 class="card-header h4 d-flex align-items-center justify-content-between">
         Resources
-
-        <%= link_to new_resource_path, class: "btn btn-sm btn-outline-secondary" do %>
-          <i class="fas fa-plus fa-fw"></i>
-        <% end %>
       </h1>
 
       <div class="list-group list-group-flush">

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,127 +1,76 @@
 <nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
   <div class="container">
     <% current_resource ? url = resource_url(current_resource) : url = landing_url %>
-    <%= link_to "Check In", url, class:"navbar-brand" %>
-
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#collapsible-nav-links" aria-controls="collapsible-nav-links" aria-expanded="false" aria-label="Toggle navigation">
+    <%= link_to "Check Ins", url, class:"navbar-brand" %>
+    <%= content_tag :button,
+                    class: "navbar-toggler",
+                    type: "button",
+                    data: { toggle: "collapse",
+                            target: "#collapsible-nav-links"},
+                    aria: { controls: "collapsible-nav-links",
+                            expanded: "false",
+                            label: "Toggle navigation"
+                          } do %>
       <span class="navbar-toggler-icon"></span>
-    </button>
+    <% end %>
 
     <div class="collapse navbar-collapse" id="collapsible-nav-links">
       <ul class="navbar-nav mr-auto">
-        <!-- <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Resources
-          </a>
-          <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-            <a href="/check_ins" class="dropdown-item">
-              Check Ins
-            </a>
-            <a href="/contexts" class="dropdown-item">
-              Contexts
-            </a>
-            <a href="/credentials" class="dropdown-item">
-              Credentials
-            </a>
-            <a href="/enrollments" class="dropdown-item">
-              Enrollments
-            </a>
-            <a href="/launches" class="dropdown-item">
-              Launches
-            </a>
-            <a href="/resources" class="dropdown-item">
-              Resources
-            </a>
-            <a href="/users" class="dropdown-item">
-              Users
-            </a>
+        <% if current_enrollment.try(:teacher?) || current_administrator %>
+          <li class="nav-item dropdown">
+            <%= link_to "Pages", "#",
+            id: "navbarDropdown",
+            class: "nav-link dropdown-toggle",
+            role:"button",
+            data: { toggle: "dropdown" },
+            aria: { haspopup: "true", expanded: "false"} %>
+            <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+              <%= link_to "Course Page", context_url(current_context), class: "dropdown-item" %>
+              <%= link_to "Sections", resources_url, class: "dropdown-item" %>
+              <% if current_administrator %>
+                <%= link_to "Credentials", credentials_url, class: "dropdown-item" %>
+              <% end %>
+            </div>
+          </li>
+        <% end %>
+      </ul>
+      <ul class="navbar-nav">
+        <li class="nav-item dropdown">
+          <%= link_to "#",
+                      id: "userDropdown",
+                      class: "nav-link dropdown-toggle",
+                      role:"button",
+                      data: { toggle: "dropdown" },
+                      aria: { haspopup: "true", expanded: "false"} do %>
+            <%= content_tag(:i, "", class: "far fa-user-circle fa-2x d-none d-lg-inline-block") %>
+            <span class="d-lg-none">User actions</span>
+          <% end %>
+          <div class="dropdown-menu dropdown-menu-right" aria-labelledby="userDropdown">
+            <% if current_enrollment %>
+                <%= link_to "Edit Profile", edit_user_url, class: "dropdown-item" %>
+                <%= link_to "Sign out", lti_user_sign_out_url, class: "dropdown-item" %>
+            <% end %>
+            <% if current_administrator.blank? %>
+              <a href="/administrators/sign_in" class="dropdown-item">
+                Administrator sign in
+              </a>
+
+              <a href="/administrators/sign_up" class="dropdown-item">
+                Administrator sign up
+              </a>
+            <% else %>
+              <a href="/administrators/edit" class="dropdown-item">
+                Administrator edit profile
+              </a>
+
+              <a href="/administrators/sign_out" data-method="delete" class="dropdown-item">
+                Administrator sign out
+              </a>
+            <% end %>
           </div>
-        </li> -->
-      </ul>
-      <!-- <ul class="navbar-nav"> -->
-        <%# if current_admin_user.blank? %>
-          <!-- <li class="nav-item">
-            <a href="/admin_users/sign_in" class="nav-link">
-
-              AdminUser sign in
-
-            </a>
-          </li>
-
-          <li class="nav-item">
-            <a href="/admin_users/sign_up" class="nav-link">
-
-              AdminUser sign up
-
-            </a>
-          </li> -->
-        <%# else %>
-          <!-- <li class="nav-item">
-            <a href="/admin_users/edit" class="nav-link">
-
-              AdminUser edit profile
-
-            </a>
-          </li>
-
-          <li class="nav-item">
-            <a href="/admin_users/sign_out" data-method="delete" class="nav-link">
-
-              AdminUser sign out
-
-            </a>
-          </li> -->
-        <%# end %>
-      <!-- </ul> -->
-      <ul class="navbar-nav">
-        <% if current_administrator.blank? %>
-          <li class="nav-item">
-            <a href="/administrators/sign_in" class="nav-link">
-
-              Administrator sign in
-
-            </a>
-          </li>
-
-          <li class="nav-item">
-            <a href="/administrators/sign_up" class="nav-link">
-
-              Administrator sign up
-
-            </a>
-          </li>
-        <% else %>
-          <li class="nav-item">
-            <a href="/administrators/edit" class="nav-link">
-
-              Administrator edit profile
-
-            </a>
-          </li>
-
-          <li class="nav-item">
-            <a href="/administrators/sign_out" data-method="delete" class="nav-link">
-
-              Administrator sign out
-
-            </a>
-          </li>
-        <% end %>
+        </li>
       </ul>
       <ul class="navbar-nav">
-        <% if current_enrollment %>
-          <li class="nav-item">
-            <%= link_to current_user.preferred_name, edit_user_url, class: "nav-link" %>
-          </li>
-
-          <li class="nav-item">
-            <a href="/sign_out" class="nav-link">
-
-              User sign out
-
-            </a>
-          </li>
-        <% end %>
       </ul>
     </div> <!-- .navbar-collapse -->
   </div> <!-- .container -->

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ Rails.application.routes.draw do
   resources :enrollments, only: []
   resource  :launch, only: :create
   resources :meetings
-  resources :resources, only: %i[edit update show]
+  resources :resources, only: %i[edit update show index]
   resources :submissions, only: %i[] do
     member do
       put "resubmit"


### PR DESCRIPTION
Teachers and administrators don't have links in the navbar to pages relevant to them. Additionally, the user actions portion of the navbar is too busy.  This PR:
- If a teacher has launched in
  - Adds links to `Context#show` and `Resource#index`
- If an administrator has signed in
  - Adds links to `Credentials#index`
- Consolidates user actions into a single dropdown

Previous navbar:
<img width="1242" alt="Screen Shot 2019-08-14 at 12 22 58 PM" src="https://user-images.githubusercontent.com/10571382/63041832-5740aa80-be8e-11e9-862b-427dd9ad1106.png">

New navbar:
<img width="1217" alt="Screen Shot 2019-08-14 at 12 25 54 PM" src="https://user-images.githubusercontent.com/10571382/63041987-af77ac80-be8e-11e9-94bd-988d96cb0263.png">
<img width="1148" alt="Screen Shot 2019-08-14 at 12 24 47 PM" src="https://user-images.githubusercontent.com/10571382/63042003-bd2d3200-be8e-11e9-84b0-a643edf19823.png">

Resolves #76 