### PR TITLE
Reorder associations for dependency

### DIFF
--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -28,9 +28,9 @@ class Attendance < ApplicationRecord
   belongs_to :meeting
   belongs_to :submission
 
+  has_one :resource, through: :submission
   has_one :context, through: :resource
   has_one :enrollment, through: :submission
-  has_one :resource, through: :submission
   has_one :user, through: :enrollment
 
   scope :accepted, -> { where(status: "accepted") }


### PR DESCRIPTION
The `Attendance#context` association was broken because `Attendance#resource`, which `#context` goes through, was defined below it. One of the features this was breaking was the ability for a teacher to comment on an attendance.