### PR TITLE
Implement Routes for Meetings

### DIFF
--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -3,32 +3,31 @@
 class MeetingsController < ApplicationController
   before_action :set_meeting, only: %i[show edit update destroy]
 
-  # GET /meetings
-  # GET /meetings.json
   def index
-    @meetings = Meeting.all
+    @resource = Resource.find(params[:resource_id])
+    authorize @resource, :show_meetings?
+    @meetings = policy_scope(Meeting).includes(:resource).where(resource: @resource).order(:start_time)
   end
 
-  # GET /meetings/1
-  # GET /meetings/1.json
-  def show; end
+  def show
+    authorize @meeting
+  end
 
-  # GET /meetings/new
   def new
-    @meeting = Meeting.new
+    @meeting = Resource.find(params[:resource_id]).meetings.build
+    authorize @meeting
   end
 
-  # GET /meetings/1/edit
-  def edit; end
+  def edit
+    authorize @meeting
+  end
 
-  # POST /meetings
-  # POST /meetings.json
   def create
     @meeting = Meeting.new(meeting_params)
-
+    authorize @meeting
     respond_to do |format|
       if @meeting.save
-        format.html { redirect_to @meeting, notice: "Meeting was successfully created." }
+        format.html { redirect_to [@meeting.resource, @meeting], notice: "Meeting was successfully created." }
         format.json { render :show, status: :created, location: @meeting }
       else
         format.html { render :new }
@@ -37,12 +36,11 @@ class MeetingsController < ApplicationController
     end
   end
 
-  # PATCH/PUT /meetings/1
-  # PATCH/PUT /meetings/1.json
   def update
+    authorize @meeting
     respond_to do |format|
       if @meeting.update(meeting_params)
-        format.html { redirect_to @meeting, notice: "Meeting was successfully updated." }
+        format.html { redirect_to [@meeting.resource, @meeting], notice: "Meeting was successfully updated." }
         format.json { render :show, status: :ok, location: @meeting }
       else
         format.html { render :edit }
@@ -51,25 +49,23 @@ class MeetingsController < ApplicationController
     end
   end
 
-  # DELETE /meetings/1
-  # DELETE /meetings/1.json
   def destroy
+    authorize @meeting
     @meeting.destroy
+
     respond_to do |format|
-      format.html { redirect_to meetings_url, notice: "Meeting was successfully destroyed." }
+      format.html { redirect_to resource_meetings_url, notice: "Meeting was successfully destroyed." }
       format.json { head :no_content }
     end
   end
 
   private
 
-  # Use callbacks to share common setup or constraints between actions.
   def set_meeting
     @meeting = Meeting.find(params[:id])
   end
 
-  # Never trust parameters from the scary internet, only allow the white list through.
   def meeting_params
-    params.require(:meeting).permit(:date, :start_time, :end_time, :resource_id)
+    params.require(:meeting).permit(:start_time, :end_time, :resource_id)
   end
 end

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -16,6 +16,7 @@ class ResourcesController < ApplicationController
   end
 
   def show
+    authorize @resource
     request.variant = if current_enrollment.teacher?
                         :teacher
                       else
@@ -26,7 +27,6 @@ class ResourcesController < ApplicationController
     if current_enrollment.teacher?
       @most_recent_meeting = @meetings.gradeable.last
     end
-    authorize @resource
   end
 
   def new

--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -23,7 +23,8 @@ class Attendance < ApplicationRecord
   has_paper_trail
   include AASM
 
-  after_save :update_submission
+  after_save           :update_submission
+  after_destroy_commit :update_submission
 
   belongs_to :meeting
   belongs_to :submission

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -27,6 +27,28 @@ class Meeting < ApplicationRecord
   }
   scope :finished, -> { where("end_time <= ?", Time.current) }
 
+  validate :start_time_earlier_than_end_time
+  validate :after_resource_start
+  validate :before_resource_end
+
+  def start_time_earlier_than_end_time
+    if start_time > end_time
+      errors.add(:base, "Start time must be earlier than end time")
+    end
+  end
+
+  def after_resource_start
+    if start_time < resource.starts_on
+      errors.add(:base, "Meeting must start after its Resource's start date (#{resource.starts_on})")
+    end
+  end
+
+  def before_resource_end
+    if start_time.to_date > resource.ends_on
+      errors.add(:base, "Meeting must start before its Resource's end date (#{resource.ends_on})")
+    end
+  end
+
   def has_approved_check_in?(enrollment)
     check_ins = enrollment.check_ins.approved
     # find a check_in that has this meeting in its target_meetings

--- a/app/policies/meeting_policy.rb
+++ b/app/policies/meeting_policy.rb
@@ -1,0 +1,47 @@
+class MeetingPolicy < ApplicationPolicy
+  attr_reader :enrollment, :record
+
+  def initialize(enrollment, record)
+    @enrollment = enrollment
+    @record = record
+  end
+
+  def show?
+    enrollment.teacher?
+  end
+
+  def index?
+    enrollment.teacher?
+  end
+
+  def create?
+    enrollment.teacher? && meeting.resource == enrollment.resource
+  end
+
+  def update?
+    enrollment.teacher? && meeting.in?(enrollment.resource.meetings)
+  end
+
+  def destroy?
+    enrollment.teacher? && meeting.resource == enrollment.resource
+  end
+
+  class Scope
+    attr_reader :enrollment, :scope
+
+    def initialize(enrollment, scope)
+      @enrollment = enrollment
+      @scope = scope
+    end
+
+    def resolve
+      enrollment.context.meetings
+    end
+  end
+
+  private
+
+  def meeting
+    record
+  end
+end

--- a/app/policies/resource_policy.rb
+++ b/app/policies/resource_policy.rb
@@ -6,6 +6,10 @@ class ResourcePolicy < ApplicationPolicy
     @record = record
   end
 
+  def show_meetings?
+    enrollment.teacher? && enrollment.in?(resource.enrollments)
+  end
+
   def index?
     true
   end
@@ -14,7 +18,7 @@ class ResourcePolicy < ApplicationPolicy
     if enrollment.teacher?
       enrollment.context == resource.context
     else
-      resource.in?(enrollment.resources)
+      resource == enrollment.resource
     end
   end
 

--- a/app/views/meetings/_form.html.erb
+++ b/app/views/meetings/_form.html.erb
@@ -1,4 +1,11 @@
-<%= form_with(model: meeting, local: true) do |form| %>
+<dl>
+  <dt>Resource Start Date:</dt>
+  <dd><%= @meeting.resource.starts_on %></dd>
+  <dt>Resource End Date:</dt>
+  <dd><%= @meeting.resource.ends_on %></dd>
+<dl>
+
+<%= form_with(model: meeting, url: [meeting.resource, meeting], local: true) do |form| %>
   <% if meeting.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(meeting.errors.count, "error") %> prohibited this meeting from being saved:</h2>
@@ -12,23 +19,17 @@
   <% end %>
 
   <div class="field">
-    <%= form.label :date %>
-    <%= form.date_select :date %>
-  </div>
-
-  <div class="field">
     <%= form.label :start_time %>
-    <%= form.time_select :start_time %>
+    <%= form.datetime_field :start_time %>
   </div>
 
   <div class="field">
     <%= form.label :end_time %>
-    <%= form.time_select :end_time %>
+    <%= form.datetime_field :end_time %>
   </div>
 
   <div class="field">
-    <%= form.label :resource_id %>
-    <%= form.number_field :resource_id %>
+    <%= form.hidden_field :resource_id %>
   </div>
 
   <div class="actions">

--- a/app/views/meetings/edit.html.erb
+++ b/app/views/meetings/edit.html.erb
@@ -2,5 +2,5 @@
 
 <%= render 'form', meeting: @meeting %>
 
-<%= link_to 'Show', @meeting %> |
-<%= link_to 'Back', meetings_path %>
+<%= link_to 'Show', resource_meeting_path(@meeting.resource, @meeting) %> |
+<%= link_to 'Back', resource_meetings_path %>

--- a/app/views/meetings/index.html.erb
+++ b/app/views/meetings/index.html.erb
@@ -5,7 +5,7 @@
 <table>
   <thead>
     <tr>
-      <th>Date</th>
+      <th>ID</th>
       <th>Start time</th>
       <th>End time</th>
       <th>Resource</th>
@@ -16,13 +16,13 @@
   <tbody>
     <% @meetings.each do |meeting| %>
       <tr>
-        <td><%= meeting.date %></td>
+        <td><%= meeting.id %></td>
         <td><%= meeting.start_time %></td>
         <td><%= meeting.end_time %></td>
         <td><%= meeting.resource_id %></td>
-        <td><%= link_to 'Show', meeting %></td>
-        <td><%= link_to 'Edit', edit_meeting_path(meeting) %></td>
-        <td><%= link_to 'Destroy', meeting, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to 'Show', resource_meeting_path(meeting.resource, meeting) %></td>
+        <td><%= link_to 'Edit', edit_resource_meeting_path(meeting.resource, meeting) %></td>
+        <td><%= link_to 'Destroy', resource_meeting_path(meeting.resource, meeting), method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
   </tbody>
@@ -30,4 +30,4 @@
 
 <br>
 
-<%= link_to 'New Meeting', new_meeting_path %>
+<%= link_to 'New Meeting', new_resource_meeting_path %>

--- a/app/views/meetings/new.html.erb
+++ b/app/views/meetings/new.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'form', meeting: @meeting %>
 
-<%= link_to 'Back', meetings_path %>
+<%= link_to 'Back', resource_meetings_path(@meeting.resource) %>

--- a/app/views/meetings/show.html.erb
+++ b/app/views/meetings/show.html.erb
@@ -15,5 +15,5 @@
   <%= @meeting.resource_id %>
 </p>
 
-<%= link_to 'Edit', edit_meeting_path(@meeting) %> |
-<%= link_to 'Back', meetings_path %>
+<%= link_to 'Edit', edit_resource_meeting_path(@meeting) %> |
+<%= link_to 'Back', resource_meetings_path(@meeting.resource) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,9 @@ Rails.application.routes.draw do
   resources :credentials, only: %i[index create destroy]
   resources :enrollments, only: []
   resource  :launch, only: :create
-  resources :resources, only: %i[edit update show index]
+  resources :resources, only: %i[edit update show index] do
+    resources :meetings, only: %i[index show edit update destroy new create]
+  end
   resources :submissions, only: %i[] do
     member do
       put "resubmit"


### PR DESCRIPTION
In anticipation of restricting access of course materials (e.g. lecture videos) to students who attended a meeting, we need more control over the meetings for a given section. This branch implements barebones routing and templates for Meetings with Pundit authorization.

This also allows us to remove/add/edit meetings without going into a console!

I'm saving styling and UX for another PR, so in order to access the meetings for a given resource, navigate to `/resources/[ID]/meetings` and then play with the routes and actions from there.

Reminder that the backdoor routes are: 
- `/teacher`
- `/student`