### PR TITLE
Fix Authorization for backdoor teacher

### DIFF
--- a/app/controllers/launches_controller.rb
+++ b/app/controllers/launches_controller.rb
@@ -28,10 +28,7 @@ class LaunchesController < ApplicationController
       find_or_create_user
       find_or_create_enrollment
       set_current_enrollment
-      @submission = Submission.find_or_create_by(
-        resource: @resource,
-        enrollment: @enrollment,
-      )
+      find_or_create_submission
       set_current_submission
       @launch = Launch.new(payload: params, credential: @credential, enrollment: @enrollment)
       if @launch.save
@@ -55,6 +52,8 @@ class LaunchesController < ApplicationController
       find_or_create_user
       find_or_create_enrollment
       set_current_enrollment
+      find_or_create_submission
+      set_current_submission
       @launch = Launch.new(payload: params, credential: @credential, enrollment: @enrollment)
       if @launch.save
         set_current_launch
@@ -112,6 +111,13 @@ class LaunchesController < ApplicationController
       redirect_to root_url,
                   notice: "Attendance assignment has not been created yet"
     end
+  end
+
+  def find_or_create_submission
+    @submission = Submission.find_or_create_by(
+      resource: @resource,
+      enrollment: @enrollment,
+    )
   end
 
   def parsed_roles

--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class MeetingsController < ApplicationController
+  before_action :set_resource
   before_action :set_meeting, only: %i[show edit update destroy]
 
   def index
-    @resource = Resource.find(params[:resource_id])
     authorize @resource, :show_meetings?
     @meetings = policy_scope(Meeting).includes(:resource).where(resource: @resource).order(:start_time)
   end
@@ -14,7 +14,7 @@ class MeetingsController < ApplicationController
   end
 
   def new
-    @meeting = Resource.find(params[:resource_id]).meetings.build
+    @meeting = @resource.meetings.build
     authorize @meeting
   end
 
@@ -61,8 +61,12 @@ class MeetingsController < ApplicationController
 
   private
 
+  def set_resource
+    @resource = Resource.find(params[:resource_id])
+  end
+  
   def set_meeting
-    @meeting = Meeting.find(params[:id])
+    @meeting = @resource.meetings.find(params[:id])
   end
 
   def meeting_params

--- a/app/policies/meeting_policy.rb
+++ b/app/policies/meeting_policy.rb
@@ -7,23 +7,19 @@ class MeetingPolicy < ApplicationPolicy
   end
 
   def show?
-    enrollment.teacher?
-  end
-
-  def index?
-    enrollment.teacher?
+    teacher_for_meeting?
   end
 
   def create?
-    enrollment.teacher? && meeting.resource == enrollment.resource
+    teacher_for_meeting?
   end
 
   def update?
-    enrollment.teacher? && meeting.in?(enrollment.resource.meetings)
+    teacher_for_meeting?
   end
 
   def destroy?
-    enrollment.teacher? && meeting.resource == enrollment.resource
+    teacher_for_meeting?
   end
 
   class Scope
@@ -43,5 +39,9 @@ class MeetingPolicy < ApplicationPolicy
 
   def meeting
     record
+  end
+
+  def teacher_for_meeting?
+    enrollment.teacher? && meeting.resource.in?(enrollment.resources)
   end
 end

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -167,5 +167,10 @@ namespace :dev do
       enrollment_id: learner_enrollment.id,
       resource_id: resource.id,
     )
+    
+    teacher_submission = Submission.find_or_create_by(
+      enrollment_id: teacher_enrollment.id,
+      resource_id: resource.id,
+    )
   end
 end


### PR DESCRIPTION
Once #91 was merged into master, I attempted to use the backdoor teacher route but was denied by Pundit. I initially thought it was an issue with the `MeetingPolicy`. In a way it was. The pundit authorization hinged on the following logic: 
```
enrollment.teacher? && meeting.resource.in?(enrollment.resources)
```
I realized the reason it wasn't working with the teacher backdoor is because there's a bug in `Launches#create`. Upon setting up a resource as a teacher, no submission is created that links the resource and the enrollment. So the policy logic is working properly. I had considered changing the policy to the following: 
```
enrollment.teacher? && meeting.context == enrollment.context
```
But I decided that was too permissive. It's important to only authorize access to a resource or its meetings only if you've been able to launch into it, not just if a resource you **have** launched into shares a common context with the resource you're attempting to access.

So, this PR: 
- Refactors some code in `MeetingPolicy` and `MeetingsController`
- Adds the creation of a submission upon resource setup by a teacher